### PR TITLE
Expand unit test coverage across layers

### DIFF
--- a/eclipse-workspace/dailyorg_java/pom.xml
+++ b/eclipse-workspace/dailyorg_java/pom.xml
@@ -83,13 +83,18 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-		    <groupId>org.springframework.boot</groupId>
-		    <artifactId>spring-boot-test</artifactId>
-		    <scope>test</scope>
-		</dependency>
+                <dependency>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-test</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
 
-	</dependencies>
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/eclipse-workspace/dailyorg_java/src/test/java/fr/nexa/dailyorg_java/controller/dailyorg/TaskControllerTest.java
+++ b/eclipse-workspace/dailyorg_java/src/test/java/fr/nexa/dailyorg_java/controller/dailyorg/TaskControllerTest.java
@@ -1,0 +1,157 @@
+package fr.nexa.dailyorg_java.controller.dailyorg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import fr.nexa.dailyorg_java.model.AppUser;
+import fr.nexa.dailyorg_java.model.dailyorg.OrganizerUser;
+import fr.nexa.dailyorg_java.model.dailyorg.Task;
+import fr.nexa.dailyorg_java.service.AppUserService;
+import fr.nexa.dailyorg_java.service.dailyorg.impl.OrganizerUserService;
+import fr.nexa.dailyorg_java.service.dailyorg.impl.TaskOccurenceService;
+import fr.nexa.dailyorg_java.service.dailyorg.impl.TaskService;
+
+@ExtendWith(MockitoExtension.class)
+public class TaskControllerTest {
+
+    @Mock
+    private TaskService taskService;
+    @Mock
+    private TaskOccurenceService taskOccurenceService;
+    @Mock
+    private AppUserService appUserService;
+    @Mock
+    private OrganizerUserService organizerUserService;
+
+    @InjectMocks
+    private TaskController taskController;
+
+    @Test
+    void testCreateTaskWithNewProfile() throws Exception {
+        Map<String, String> data = new HashMap<>();
+        data.put("task_name", "MyTask");
+        data.put("task_required_energy", "5");
+        data.put("user_email", "test@test.com");
+        data.put("task_start_date", "2024-01-01T10:00:00");
+        data.put("task_end_date", "2024-01-01T12:00:00");
+
+        AppUser user = AppUser.builder().userId(1L).email("test@test.com").build();
+
+        when(appUserService.findByEmail("test@test.com")).thenReturn(Optional.of(user));
+        when(organizerUserService.create(any(OrganizerUser.class))).thenAnswer(inv -> {
+            OrganizerUser ou = inv.getArgument(0);
+            ou.setOrganizerUserId(1L);
+            return ou;
+        });
+        when(appUserService.updateUser(any(AppUser.class))).thenReturn(user);
+        when(taskService.addTask(any(Task.class))).thenReturn(Task.builder().taskId(1L).taskName("MyTask").build());
+
+        ResponseEntity<?> response = taskController.createTask(data);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo("Task and profile created...");
+    }
+
+    @Test
+    void testCreateTaskUserNotFound() throws Exception {
+        Map<String, String> data = new HashMap<>();
+        data.put("task_name", "MyTask");
+        data.put("task_required_energy", "5");
+        data.put("user_email", "test@test.com");
+        data.put("task_start_date", "2024-01-01T10:00:00");
+        data.put("task_end_date", "2024-01-01T12:00:00");
+
+        when(appUserService.findByEmail("test@test.com")).thenReturn(Optional.empty());
+
+        ResponseEntity<?> response = taskController.createTask(data);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void testUpdateTask() throws Exception {
+        Map<String, String> data = new HashMap<>();
+        data.put("task_id", "1");
+        data.put("task_name", "Updated");
+        data.put("task_required_energy", "10");
+        data.put("user_email", "test@test.com");
+        data.put("task_start_date", "2024-01-01T10:00:00");
+        data.put("task_end_date", "2024-01-01T12:00:00");
+
+        AppUser user = AppUser.builder().userId(1L).email("test@test.com").build();
+        OrganizerUser organizerUser = OrganizerUser.builder().organizerUserId(1L).appUser(user).build();
+        user.setOrganizerUser(organizerUser);
+        Task task = Task.builder().taskId(1L).taskName("Old").organizerUser(organizerUser)
+                .taskRequiredEnergy(5)
+                .taskStartDate(LocalDateTime.now()).taskEndDate(LocalDateTime.now())
+                .build();
+
+        when(appUserService.findByEmail("test@test.com")).thenReturn(Optional.of(user));
+        when(taskService.getTaskById(1L)).thenReturn(task);
+        when(taskService.updateTask(any(Task.class))).thenReturn(task);
+
+        ResponseEntity<?> response = taskController.updateTask(data);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo("Task updated successfully...");
+    }
+
+    @Test
+    void testDeleteTask() throws Exception {
+        Map<String, String> data = new HashMap<>();
+        data.put("task_id", "1");
+        data.put("user_email", "test@test.com");
+
+        AppUser user = AppUser.builder().userId(1L).email("test@test.com").build();
+        OrganizerUser organizerUser = OrganizerUser.builder().organizerUserId(1L).appUser(user).build();
+        user.setOrganizerUser(organizerUser);
+        Task task = Task.builder().taskId(1L).organizerUser(organizerUser).build();
+
+        when(appUserService.findByEmail("test@test.com")).thenReturn(Optional.of(user));
+        when(taskService.getTaskById(1L)).thenReturn(task);
+        when(taskService.deleteTask(1L)).thenReturn(task);
+
+        ResponseEntity<?> response = taskController.deleteTask(data);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo("Task deleted successfully...");
+    }
+
+    @Test
+    void testGetTasksByDate() throws Exception {
+        Map<String, String> data = new HashMap<>();
+        data.put("user_email", "test@test.com");
+        data.put("date", "2024-01-01T10:00:00");
+
+        AppUser user = AppUser.builder().userId(1L).email("test@test.com").build();
+        OrganizerUser organizerUser = OrganizerUser.builder().organizerUserId(1L).appUser(user).build();
+        user.setOrganizerUser(organizerUser);
+        Task task = Task.builder().taskId(1L).taskName("MyTask").build();
+
+        when(appUserService.findByEmail("test@test.com")).thenReturn(Optional.of(user));
+        when(organizerUserService.findByAppUserId(user)).thenReturn(organizerUser);
+        when(taskService.getAllTasksByUserIdAndDate(organizerUser, LocalDateTime.parse("2024-01-01T10:00:00")))
+                .thenReturn(List.of(task));
+
+        ResponseEntity<?> response = taskController.getTasksByDate(data);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isInstanceOf(List.class);
+    }
+}
+

--- a/eclipse-workspace/dailyorg_java/src/test/java/fr/nexa/dailyorg_java/controller/workout/WorkoutSessionControllerTest.java
+++ b/eclipse-workspace/dailyorg_java/src/test/java/fr/nexa/dailyorg_java/controller/workout/WorkoutSessionControllerTest.java
@@ -1,0 +1,69 @@
+package fr.nexa.dailyorg_java.controller.workout;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import fr.nexa.dailyorg_java.model.AppUser;
+import fr.nexa.dailyorg_java.model.workout.WorkoutSession;
+import fr.nexa.dailyorg_java.service.AppUserService;
+import fr.nexa.dailyorg_java.service.workout.impl.WorkoutRecordService;
+import fr.nexa.dailyorg_java.service.workout.impl.WorkoutSessionService;
+import fr.nexa.dailyorg_java.service.workout.impl.StrengthExerciseService;
+import fr.nexa.dailyorg_java.service.workout.impl.CardioExerciseService;
+import fr.nexa.dailyorg_java.service.workout.impl.ExerciseService;
+
+@ExtendWith(MockitoExtension.class)
+public class WorkoutSessionControllerTest {
+
+    @Mock
+    private WorkoutRecordService workoutRecordService;
+    @Mock
+    private WorkoutSessionService workoutSessionService;
+    @Mock
+    private StrengthExerciseService strengthExerciseService;
+    @Mock
+    private CardioExerciseService cardioExerciseService;
+    @Mock
+    private AppUserService appUserService;
+    @Mock
+    private ExerciseService exerciseService;
+
+    @InjectMocks
+    private WorkoutSessionController workoutSessionController;
+
+    @Test
+    void testCreateWorkout() throws Exception {
+        Map<String, String> data = new HashMap<>();
+        data.put("email", "test@test.com");
+
+        AppUser user = AppUser.builder().userId(1L).email("test@test.com").build();
+        when(appUserService.findByEmail("test@test.com")).thenReturn(Optional.of(user));
+        when(workoutSessionService.addWorkoutSession(any(WorkoutSession.class))).thenReturn(new WorkoutSession());
+
+        ResponseEntity<String> response = workoutSessionController.createWorkout(data);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void testDeleteWorkout() throws Exception {
+        Map<String, String> data = new HashMap<>();
+        data.put("email", "test@test.com");
+        data.put("workout_session_id", "1");
+
+        ResponseEntity<String> response = workoutSessionController.deleteWorkout(data);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+}

--- a/eclipse-workspace/dailyorg_java/src/test/java/fr/nexa/dailyorg_java/model/dailyorg/TaskModelTest.java
+++ b/eclipse-workspace/dailyorg_java/src/test/java/fr/nexa/dailyorg_java/model/dailyorg/TaskModelTest.java
@@ -1,0 +1,25 @@
+package fr.nexa.dailyorg_java.model.dailyorg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+
+public class TaskModelTest {
+
+    @Test
+    void testPrePersistSetsCreationDate() {
+        Task task = Task.builder()
+                .taskName("Test")
+                .taskRequiredEnergy(1)
+                .taskStartDate(LocalDateTime.now())
+                .taskEndDate(LocalDateTime.now())
+                .build();
+
+        // creation date should be null before
+        assertThat(task.getTaskCreationDate()).isNull();
+        task.prePersist();
+        assertThat(task.getTaskCreationDate()).isNotNull();
+    }
+}

--- a/eclipse-workspace/dailyorg_java/src/test/java/fr/nexa/dailyorg_java/repository/dailyorg/TaskRepositoryTest.java
+++ b/eclipse-workspace/dailyorg_java/src/test/java/fr/nexa/dailyorg_java/repository/dailyorg/TaskRepositoryTest.java
@@ -1,0 +1,37 @@
+package fr.nexa.dailyorg_java.repository.dailyorg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import fr.nexa.dailyorg_java.model.dailyorg.Task;
+import fr.nexa.dailyorg_java.model.dailyorg.OrganizerUser;
+
+@DataJpaTest
+public class TaskRepositoryTest {
+
+    @Autowired
+    private ITaskRepository taskRepository;
+
+    @Test
+    void testSaveAndFindById() {
+        OrganizerUser user = OrganizerUser.builder().energy_profile("A").level(0).exp_points(0).build();
+        Task task = Task.builder()
+                .taskName("Test")
+                .taskRequiredEnergy(1)
+                .taskStartDate(LocalDateTime.now())
+                .taskEndDate(LocalDateTime.now())
+                .organizerUser(user)
+                .build();
+        task = taskRepository.save(task);
+        assertThat(task.getTaskId()).isGreaterThan(0);
+
+        Task found = taskRepository.findById(task.getTaskId()).orElse(null);
+        assertThat(found).isNotNull();
+        assertThat(found.getTaskName()).isEqualTo("Test");
+    }
+}


### PR DESCRIPTION
## Summary
- add Task model test checking `prePersist`
- include in-memory repository test for `ITaskRepository`
- add workout controller tests for creating and deleting workouts
- include H2 for testing in `pom.xml`

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684aeaec81b8832a8a976d5754aa3c9e